### PR TITLE
Fix link templates for Karp 7

### DIFF
--- a/attributes/positional/lex.yaml
+++ b/attributes/positional/lex.yaml
@@ -3,8 +3,8 @@ extended_component:
   options:
     error_on_empty: true
     type: lemgram
-external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-  val.replace(/:\d+/, '') %>
+external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+  val.replace(/:\d+/, '') %>")
 internal_search: true
 label: lemgram
 opts:

--- a/attributes/positional/prefix-old.yaml
+++ b/attributes/positional/prefix-old.yaml
@@ -4,7 +4,7 @@ extended_component:
     error_on_empty: true
     type: lemgram
     variant: affix
-external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%= val.replace(/:\d+/, '') %>
+external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%= val.replace(/:\d+/, '') %>")
 internal_search: true
 label:
   eng: initial part

--- a/attributes/positional/sense-old.yaml
+++ b/attributes/positional/sense-old.yaml
@@ -3,7 +3,7 @@ extended_component:
   options:
     error_on_empty: true
     type: sense
-external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|sense|equals|<%= val %>
+external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldo&query=and(equals|senseID|"<%= val %>")
 internal_search: true
 label:
   eng: sense

--- a/attributes/positional/sense.yaml
+++ b/attributes/positional/sense.yaml
@@ -3,7 +3,7 @@ extended_component:
   options:
     error_on_empty: true
     type: sense
-external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|sense|equals|<%= val %>
+external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldo&query=and(equals|senseID|"<%= val %>")
 internal_search: true
 label:
   eng: sense

--- a/attributes/positional/suffix-old.yaml
+++ b/attributes/positional/suffix-old.yaml
@@ -4,8 +4,8 @@ extended_component:
     error_on_empty: true
     type: lemgram
     variant: affix
-external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-  val.replace(/:\d+/, '') %>
+external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+  val.replace(/:\d+/, '') %>")
 internal_search: true
 label:
   eng: final part

--- a/attributes/positional/swefn.yaml
+++ b/attributes/positional/swefn.yaml
@@ -1,4 +1,4 @@
-external_search: https://spraakbanken.gu.se/karp/#?mode=swefn&search=sense%7C%7Cswefn--<%= val %>
+external_search: https://spraakbanken.gu.se/karp/?mode=swefn&lexicon=swefn&query=and(equals|swefnID|"<%= val %>")
 internal_search: true
 label:
   eng: Swedish FrameNet

--- a/attributes/structural/text_swefn.yaml
+++ b/attributes/structural/text_swefn.yaml
@@ -1,4 +1,4 @@
-external_search: https://spraakbanken.gu.se/karp/#?mode=swefn&search=sense%7C%7Cswefn--<%= val %>
+external_search: https://spraakbanken.gu.se/karp/?mode=swefn&lexicon=swefn&query=and(equals|swefnID|"<%= val %>")
 is_struct_attr: true
 label:
   eng: Swedish FrameNet

--- a/corpora/bellman.yaml
+++ b/corpora/bellman.yaml
@@ -32,8 +32,8 @@ pos_attributes:
           error_on_empty: true
           type: lemgram
           variant: dalin
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: dalin-lemgram
       opts:

--- a/corpora/betankande.yaml
+++ b/corpora/betankande.yaml
@@ -31,8 +31,8 @@ pos_attributes:
           error_on_empty: true
           type: lemgram
           variant: dalin
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: dalin-lemgram
       opts:

--- a/corpora/fsv-aldrelagar.yaml
+++ b/corpora/fsv-aldrelagar.yaml
@@ -144,8 +144,8 @@ pos_attributes:
         options:
           error_on_empty: true
           type: lemgram
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label:
         eng: similar lemgram
@@ -170,8 +170,8 @@ pos_attributes:
         options:
           error_on_empty: true
           type: lemgram
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: lemgram
       opts:

--- a/corpora/fsv-aldrereligiosprosa.yaml
+++ b/corpora/fsv-aldrereligiosprosa.yaml
@@ -142,8 +142,8 @@ pos_attributes:
         options:
           error_on_empty: true
           type: lemgram
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label:
         eng: similar lemgram
@@ -168,8 +168,8 @@ pos_attributes:
         options:
           error_on_empty: true
           type: lemgram
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: lemgram
       opts:

--- a/corpora/fsv-nysvensklagar.yaml
+++ b/corpora/fsv-nysvensklagar.yaml
@@ -33,8 +33,8 @@ pos_attributes:
         options:
           error_on_empty: true
           type: lemgram
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: lemgram
       opts:

--- a/corpora/fsv-profanprosa.yaml
+++ b/corpora/fsv-profanprosa.yaml
@@ -142,8 +142,8 @@ pos_attributes:
         options:
           error_on_empty: true
           type: lemgram
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label:
         eng: similar lemgram
@@ -168,8 +168,8 @@ pos_attributes:
         options:
           error_on_empty: true
           type: lemgram
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: lemgram
       opts:

--- a/corpora/fsv-verser.yaml
+++ b/corpora/fsv-verser.yaml
@@ -142,8 +142,8 @@ pos_attributes:
         options:
           error_on_empty: true
           type: lemgram
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label:
         eng: similar lemgram
@@ -168,8 +168,8 @@ pos_attributes:
         options:
           error_on_empty: true
           type: lemgram
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: lemgram
       opts:

--- a/corpora/fsv-yngrelagar.yaml
+++ b/corpora/fsv-yngrelagar.yaml
@@ -144,8 +144,8 @@ pos_attributes:
         options:
           error_on_empty: true
           type: lemgram
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label:
         eng: similar lemgram
@@ -170,8 +170,8 @@ pos_attributes:
         options:
           error_on_empty: true
           type: lemgram
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: lemgram
       opts:

--- a/corpora/fsv-yngrereligiosprosa.yaml
+++ b/corpora/fsv-yngrereligiosprosa.yaml
@@ -142,8 +142,8 @@ pos_attributes:
         options:
           error_on_empty: true
           type: lemgram
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label:
         eng: similar lemgram
@@ -168,8 +168,8 @@ pos_attributes:
         options:
           error_on_empty: true
           type: lemgram
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: lemgram
       opts:

--- a/corpora/fsv-yngretankebocker.yaml
+++ b/corpora/fsv-yngretankebocker.yaml
@@ -142,8 +142,8 @@ pos_attributes:
         options:
           error_on_empty: true
           type: lemgram
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label:
         eng: similar lemgram
@@ -168,8 +168,8 @@ pos_attributes:
         options:
           error_on_empty: true
           type: lemgram
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: lemgram
       opts:

--- a/corpora/kubhist2-dalpilen-1910.yaml
+++ b/corpora/kubhist2-dalpilen-1910.yaml
@@ -27,8 +27,8 @@ pos_attributes:
           error_on_empty: true
           type: lemgram
           variant: dalin
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: dalin-lemgram
       opts:

--- a/corpora/kubhist2-dalpilen-1920.yaml
+++ b/corpora/kubhist2-dalpilen-1920.yaml
@@ -27,8 +27,8 @@ pos_attributes:
           error_on_empty: true
           type: lemgram
           variant: dalin
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: dalin-lemgram
       opts:

--- a/corpora/kubhist2-kalmar-1910.yaml
+++ b/corpora/kubhist2-kalmar-1910.yaml
@@ -27,8 +27,8 @@ pos_attributes:
           error_on_empty: true
           type: lemgram
           variant: dalin
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: dalin-lemgram
       opts:

--- a/corpora/kubhist2-kalmar-kalmarlanstidning-1910.yaml
+++ b/corpora/kubhist2-kalmar-kalmarlanstidning-1910.yaml
@@ -27,8 +27,8 @@ pos_attributes:
           error_on_empty: true
           type: lemgram
           variant: dalin
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: dalin-lemgram
       opts:

--- a/corpora/kubhist2-ostgotaposten-1910.yaml
+++ b/corpora/kubhist2-ostgotaposten-1910.yaml
@@ -27,8 +27,8 @@ pos_attributes:
           error_on_empty: true
           type: lemgram
           variant: dalin
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: dalin-lemgram
       opts:

--- a/corpora/npegl-eng.yaml
+++ b/corpora/npegl-eng.yaml
@@ -7,7 +7,7 @@ custom_attributes:
   - karp_link:
       custom_type: pos
       label: Karp
-      pattern: <a href='https://spraakbanken.gu.se/karp/tng/?mode=npegl_old_english&lexicon=npegl_old_english&query=and(equals|DB_item_id|%22<%= pos_attrs.np_db_item_id %>%22)' target='_blank'>go to entry</a>
+      pattern: <a href='https://spraakbanken.gu.se/karp/?mode=npegl_old_english&lexicon=npegl_old_english&query=and(equals|DB_item_id|"<%= pos_attrs.np_db_item_id %>")' target='_blank'>go to entry</a>
 description: ''
 id: npegl-eng
 limited_access: false

--- a/corpora/npegl-ger.yaml
+++ b/corpora/npegl-ger.yaml
@@ -7,7 +7,7 @@ custom_attributes:
   - karp_link:
       custom_type: pos
       label: Karp
-      pattern: <a href='https://spraakbanken.gu.se/karp/tng/?mode=npegl_old_high_german&lexicon=npegl_old_high_german&query=and(equals|DB_item_id|%22<%= pos_attrs.np_db_item_id %>%22)' target='_blank'>go to entry</a>
+      pattern: <a href='https://spraakbanken.gu.se/karp/?mode=npegl_old_high_german&lexicon=npegl_old_high_german&query=and(equals|DB_item_id|"<%= pos_attrs.np_db_item_id %>")' target='_blank'>go to entry</a>
 description: ''
 id: npegl-ger
 limited_access: false

--- a/corpora/npegl-ice.yaml
+++ b/corpora/npegl-ice.yaml
@@ -7,7 +7,7 @@ custom_attributes:
   - karp_link:
       custom_type: pos
       label: Karp
-      pattern: <a href='https://spraakbanken.gu.se/karp/tng/?mode=npegl_old_icelandic&lexicon=npegl_old_icelandic&query=and(equals|DB_item_id|%22<%= pos_attrs.np_db_item_id %>%22)' target='_blank'>go to entry</a>
+      pattern: <a href='https://spraakbanken.gu.se/karp/?mode=npegl_old_icelandic&lexicon=npegl_old_icelandic&query=and(equals|DB_item_id|"<%= pos_attrs.np_db_item_id %>")' target='_blank'>go to entry</a>
 description: ''
 id: npegl-ice
 limited_access: false

--- a/corpora/npegl-sax.yaml
+++ b/corpora/npegl-sax.yaml
@@ -7,7 +7,7 @@ custom_attributes:
   - karp_link:
       custom_type: pos
       label: Karp
-      pattern: <a href='https://spraakbanken.gu.se/karp/tng/?mode=npegl_old_saxon&lexicon=npegl_old_saxon&query=and(equals|DB_item_id|%22<%= pos_attrs.np_db_item_id %>%22)' target='_blank'>go to entry</a>
+      pattern: <a href='https://spraakbanken.gu.se/karp/?mode=npegl_old_saxon&lexicon=npegl_old_saxon&query=and(equals|DB_item_id|"<%= pos_attrs.np_db_item_id %>")' target='_blank'>go to entry</a>
 description: ''
 id: npegl-sax
 limited_access: false

--- a/corpora/npegl-swe.yaml
+++ b/corpora/npegl-swe.yaml
@@ -7,7 +7,7 @@ custom_attributes:
   - karp_link:
       custom_type: pos
       label: Karp
-      pattern: <a href='https://spraakbanken.gu.se/karp/tng/?mode=npegl_old_swedish&lexicon=npegl_old_swedish&query=and(equals|DB_item_id|%22<%= pos_attrs.np_db_item_id %>%22)' target='_blank'>go to entry</a>
+      pattern: <a href='https://spraakbanken.gu.se/karp/?mode=npegl_old_swedish&lexicon=npegl_old_swedish&query=and(equals|DB_item_id|"<%= pos_attrs.np_db_item_id %>")' target='_blank'>go to entry</a>
 description: ''
 id: npegl-swe
 limited_access: false

--- a/corpora/ub-kvt-dagny.yaml
+++ b/corpora/ub-kvt-dagny.yaml
@@ -20,8 +20,8 @@ pos_attributes:
           error_on_empty: true
           type: lemgram
           variant: dalin
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: dalin-lemgram
       opts:

--- a/corpora/ub-kvt-hertha.yaml
+++ b/corpora/ub-kvt-hertha.yaml
@@ -20,8 +20,8 @@ pos_attributes:
           error_on_empty: true
           type: lemgram
           variant: dalin
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: dalin-lemgram
       opts:

--- a/corpora/ub-kvt-idun.yaml
+++ b/corpora/ub-kvt-idun.yaml
@@ -20,8 +20,8 @@ pos_attributes:
           error_on_empty: true
           type: lemgram
           variant: dalin
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: dalin-lemgram
       opts:

--- a/corpora/ub-kvt-kvt.yaml
+++ b/corpora/ub-kvt-kvt.yaml
@@ -19,8 +19,8 @@ pos_attributes:
           error_on_empty: true
           type: lemgram
           variant: dalin
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: dalin-lemgram
       opts:

--- a/corpora/ub-kvt-morgonbris.yaml
+++ b/corpora/ub-kvt-morgonbris.yaml
@@ -20,8 +20,8 @@ pos_attributes:
           error_on_empty: true
           type: lemgram
           variant: dalin
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: dalin-lemgram
       opts:

--- a/corpora/ub-kvt-rostratt.yaml
+++ b/corpora/ub-kvt-rostratt.yaml
@@ -20,8 +20,8 @@ pos_attributes:
           error_on_empty: true
           type: lemgram
           variant: dalin
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: dalin-lemgram
       opts:

--- a/corpora/ub-kvt-tidevarvet.yaml
+++ b/corpora/ub-kvt-tidevarvet.yaml
@@ -19,8 +19,8 @@ pos_attributes:
           error_on_empty: true
           type: lemgram
           variant: dalin
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: dalin-lemgram
       opts:

--- a/corpora/vasabibel-nt.yaml
+++ b/corpora/vasabibel-nt.yaml
@@ -25,8 +25,8 @@ pos_attributes:
           error_on_empty: true
           type: lemgram
           variant: dalin
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: dalin-lemgram
       opts:

--- a/corpora/vasabrev.yaml
+++ b/corpora/vasabrev.yaml
@@ -20,8 +20,8 @@ pos_attributes:
           error_on_empty: true
           type: lemgram
           variant: dalin
-      external_search: https://spraakbanken.gu.se/karp/#?mode=DEFAULT&search=extended||and|lemgram|equals|<%=
-        val.replace(/:\d+/, '') %>
+      external_search: https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"<%=
+        val.replace(/:\d+/, '') %>")
       internal_search: true
       label: dalin-lemgram
       opts:


### PR DESCRIPTION
Examples of links of new formats:

lemgram:
https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldom&query=and(equals|lemgram|"speciell..av.1")

senseID:
https://spraakbanken.gu.se/karp/?mode=saldom&lexicon=saldo&query=and(equals|senseID|"ryggradslös..2")

swefnID:
https://spraakbanken.gu.se/karp/?mode=swefn&lexicon=swefn&query=and(equals|swefnID|"Atonement")

(NPEGL) DB_item_id:
https://spraakbanken.gu.se/karp/?mode=npegl_old_english&lexicon=npegl_old_english&query=and(equals|DB_item_id|"OEng.952.904")