### PR TITLE
fix: remove broken Kubhist2 thumbs

### DIFF
--- a/corpora/kubhist2-aftonbladet-1830.yaml
+++ b/corpora/kubhist2-aftonbladet-1830.yaml
@@ -59,11 +59,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - text_date: date
 pos_attributes:
   - ne_ex: ne_ex

--- a/corpora/kubhist2-aftonbladet-1840.yaml
+++ b/corpora/kubhist2-aftonbladet-1840.yaml
@@ -39,11 +39,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-aftonbladet-1850.yaml
+++ b/corpora/kubhist2-aftonbladet-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-aftonbladet-1860.yaml
+++ b/corpora/kubhist2-aftonbladet-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-aftonbladet-1870.yaml
+++ b/corpora/kubhist2-aftonbladet-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-aftonbladet-1880.yaml
+++ b/corpora/kubhist2-aftonbladet-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-aftonbladet-1890.yaml
+++ b/corpora/kubhist2-aftonbladet-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-aftonbladet-1900.yaml
+++ b/corpora/kubhist2-aftonbladet-1900.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-alfwarochskamt-1840.yaml
+++ b/corpora/kubhist2-alfwarochskamt-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-barometern-1840.yaml
+++ b/corpora/kubhist2-barometern-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-barometern-1850.yaml
+++ b/corpora/kubhist2-barometern-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-barometern-1860.yaml
+++ b/corpora/kubhist2-barometern-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-barometern-1870.yaml
+++ b/corpora/kubhist2-barometern-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-barometern-1880.yaml
+++ b/corpora/kubhist2-barometern-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-barometern-1890.yaml
+++ b/corpora/kubhist2-barometern-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-blekingsposten-1850.yaml
+++ b/corpora/kubhist2-blekingsposten-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-blekingsposten-1860.yaml
+++ b/corpora/kubhist2-blekingsposten-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-blekingsposten-1870.yaml
+++ b/corpora/kubhist2-blekingsposten-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-blekingsposten-1880.yaml
+++ b/corpora/kubhist2-blekingsposten-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-bollnastidning-1870.yaml
+++ b/corpora/kubhist2-bollnastidning-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-bollnastidning-1880.yaml
+++ b/corpora/kubhist2-bollnastidning-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-borastidning-1830.yaml
+++ b/corpora/kubhist2-borastidning-1830.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-borastidning-1840.yaml
+++ b/corpora/kubhist2-borastidning-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-borastidning-1850.yaml
+++ b/corpora/kubhist2-borastidning-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-borastidning-1860.yaml
+++ b/corpora/kubhist2-borastidning-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-borastidning-1870.yaml
+++ b/corpora/kubhist2-borastidning-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-borastidning-1880.yaml
+++ b/corpora/kubhist2-borastidning-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-borastidning-1890.yaml
+++ b/corpora/kubhist2-borastidning-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-carlscronastidningar-1760.yaml
+++ b/corpora/kubhist2-carlscronastidningar-1760.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-carlscronaswekoblad-1750.yaml
+++ b/corpora/kubhist2-carlscronaswekoblad-1750.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-carlscronaswekoblad-1760.yaml
+++ b/corpora/kubhist2-carlscronaswekoblad-1760.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-carlscronaswekoblad-1770.yaml
+++ b/corpora/kubhist2-carlscronaswekoblad-1770.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-carlscronaswekoblad-1780.yaml
+++ b/corpora/kubhist2-carlscronaswekoblad-1780.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-carlscronaswekoblad-1790.yaml
+++ b/corpora/kubhist2-carlscronaswekoblad-1790.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-carlscronaswekoblad-1800.yaml
+++ b/corpora/kubhist2-carlscronaswekoblad-1800.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-carlscronaswekoblad-1810.yaml
+++ b/corpora/kubhist2-carlscronaswekoblad-1810.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-carlscronaswekoblad-1820.yaml
+++ b/corpora/kubhist2-carlscronaswekoblad-1820.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-carlscronaswekoblad-1830.yaml
+++ b/corpora/kubhist2-carlscronaswekoblad-1830.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-carlscronaswekoblad-1840.yaml
+++ b/corpora/kubhist2-carlscronaswekoblad-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-carlscronaswekoblad-1850.yaml
+++ b/corpora/kubhist2-carlscronaswekoblad-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-carlscronaswekoblad-1860.yaml
+++ b/corpora/kubhist2-carlscronaswekoblad-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-carlscronaswekoblad-1870.yaml
+++ b/corpora/kubhist2-carlscronaswekoblad-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-dagligtallehanda-1760.yaml
+++ b/corpora/kubhist2-dagligtallehanda-1760.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-dagligtallehanda-1770.yaml
+++ b/corpora/kubhist2-dagligtallehanda-1770.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-dagligtallehanda-1780.yaml
+++ b/corpora/kubhist2-dagligtallehanda-1780.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-dagligtallehanda-1790.yaml
+++ b/corpora/kubhist2-dagligtallehanda-1790.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-dagligtallehanda-1800.yaml
+++ b/corpora/kubhist2-dagligtallehanda-1800.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-dagligtallehanda-1810.yaml
+++ b/corpora/kubhist2-dagligtallehanda-1810.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-dagligtallehanda-1820.yaml
+++ b/corpora/kubhist2-dagligtallehanda-1820.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-dagligtallehanda-1830.yaml
+++ b/corpora/kubhist2-dagligtallehanda-1830.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-dagligtallehanda-1840.yaml
+++ b/corpora/kubhist2-dagligtallehanda-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-dalpilen-1850.yaml
+++ b/corpora/kubhist2-dalpilen-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-dalpilen-1860.yaml
+++ b/corpora/kubhist2-dalpilen-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-dalpilen-1870.yaml
+++ b/corpora/kubhist2-dalpilen-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-dalpilen-1880.yaml
+++ b/corpora/kubhist2-dalpilen-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-dalpilen-1890.yaml
+++ b/corpora/kubhist2-dalpilen-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-dalpilen-1900.yaml
+++ b/corpora/kubhist2-dalpilen-1900.yaml
@@ -47,11 +47,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - text_title:
       label:
         eng: title

--- a/corpora/kubhist2-dalpilen-1910.yaml
+++ b/corpora/kubhist2-dalpilen-1910.yaml
@@ -69,11 +69,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - text_blingbring: text_blingbring
   - text_swefn: text_swefn
   - text_lix: text_lix

--- a/corpora/kubhist2-dalpilen-1920.yaml
+++ b/corpora/kubhist2-dalpilen-1920.yaml
@@ -69,11 +69,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - text_blingbring: text_blingbring
   - text_swefn: text_swefn
   - text_lix: text_lix

--- a/corpora/kubhist2-fahluweckoblad-1780.yaml
+++ b/corpora/kubhist2-fahluweckoblad-1780.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-fahluweckoblad-1790.yaml
+++ b/corpora/kubhist2-fahluweckoblad-1790.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-fahluweckoblad-1800.yaml
+++ b/corpora/kubhist2-fahluweckoblad-1800.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-fahluweckoblad-1810.yaml
+++ b/corpora/kubhist2-fahluweckoblad-1810.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-fahluweckoblad-1820.yaml
+++ b/corpora/kubhist2-fahluweckoblad-1820.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-falkopingstidning-1850.yaml
+++ b/corpora/kubhist2-falkopingstidning-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-falkopingstidning-1860.yaml
+++ b/corpora/kubhist2-falkopingstidning-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-falkopingstidning-1870.yaml
+++ b/corpora/kubhist2-falkopingstidning-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-falkopingstidning-1880.yaml
+++ b/corpora/kubhist2-falkopingstidning-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-falkopingstidning-1890.yaml
+++ b/corpora/kubhist2-falkopingstidning-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-faluposten-1860.yaml
+++ b/corpora/kubhist2-faluposten-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-faluposten-1870.yaml
+++ b/corpora/kubhist2-faluposten-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-faluposten-1880.yaml
+++ b/corpora/kubhist2-faluposten-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-faluposten-1890.yaml
+++ b/corpora/kubhist2-faluposten-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-folketsrost-1840.yaml
+++ b/corpora/kubhist2-folketsrost-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-folketsrost-1850.yaml
+++ b/corpora/kubhist2-folketsrost-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-folketsrost-1860.yaml
+++ b/corpora/kubhist2-folketsrost-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ghost-1830.yaml
+++ b/corpora/kubhist2-ghost-1830.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ghost-1840.yaml
+++ b/corpora/kubhist2-ghost-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ghost-1850.yaml
+++ b/corpora/kubhist2-ghost-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ghost-1860.yaml
+++ b/corpora/kubhist2-ghost-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ghost-1870.yaml
+++ b/corpora/kubhist2-ghost-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ghost-1880.yaml
+++ b/corpora/kubhist2-ghost-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ghost-1890.yaml
+++ b/corpora/kubhist2-ghost-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-goteborgsposten-1850.yaml
+++ b/corpora/kubhist2-goteborgsposten-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-goteborgsposten-1860.yaml
+++ b/corpora/kubhist2-goteborgsposten-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-goteborgsposten-1870.yaml
+++ b/corpora/kubhist2-goteborgsposten-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-goteborgsposten-1880.yaml
+++ b/corpora/kubhist2-goteborgsposten-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-goteborgsposten-1890.yaml
+++ b/corpora/kubhist2-goteborgsposten-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-goteborgsweckoblad-1870.yaml
+++ b/corpora/kubhist2-goteborgsweckoblad-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-goteborgsweckoblad-1880.yaml
+++ b/corpora/kubhist2-goteborgsweckoblad-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-goteborgsweckoblad-1890.yaml
+++ b/corpora/kubhist2-goteborgsweckoblad-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgsallehanda-1770.yaml
+++ b/corpora/kubhist2-gotheborgsallehanda-1770.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgsallehanda-1780.yaml
+++ b/corpora/kubhist2-gotheborgsallehanda-1780.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgsallehanda-1790.yaml
+++ b/corpora/kubhist2-gotheborgsallehanda-1790.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgsallehanda-1800.yaml
+++ b/corpora/kubhist2-gotheborgsallehanda-1800.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgsallehanda-1810.yaml
+++ b/corpora/kubhist2-gotheborgsallehanda-1810.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgsallehanda-1820.yaml
+++ b/corpora/kubhist2-gotheborgsallehanda-1820.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgsallehanda-1830.yaml
+++ b/corpora/kubhist2-gotheborgsallehanda-1830.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgsallehanda-1840.yaml
+++ b/corpora/kubhist2-gotheborgsallehanda-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgskanyheter-1760.yaml
+++ b/corpora/kubhist2-gotheborgskanyheter-1760.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgskanyheter-1770.yaml
+++ b/corpora/kubhist2-gotheborgskanyheter-1770.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgskanyheter-1780.yaml
+++ b/corpora/kubhist2-gotheborgskanyheter-1780.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgskanyheter-1790.yaml
+++ b/corpora/kubhist2-gotheborgskanyheter-1790.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgskanyheter-1800.yaml
+++ b/corpora/kubhist2-gotheborgskanyheter-1800.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgskanyheter-1810.yaml
+++ b/corpora/kubhist2-gotheborgskanyheter-1810.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgskanyheter-1820.yaml
+++ b/corpora/kubhist2-gotheborgskanyheter-1820.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgskanyheter-1830.yaml
+++ b/corpora/kubhist2-gotheborgskanyheter-1830.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgskanyheter-1840.yaml
+++ b/corpora/kubhist2-gotheborgskanyheter-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgsweckolista-1740.yaml
+++ b/corpora/kubhist2-gotheborgsweckolista-1740.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotheborgsweckolista-1750.yaml
+++ b/corpora/kubhist2-gotheborgsweckolista-1750.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotlandstidning-1860.yaml
+++ b/corpora/kubhist2-gotlandstidning-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotlandstidning-1870.yaml
+++ b/corpora/kubhist2-gotlandstidning-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-gotlandstidning-1880.yaml
+++ b/corpora/kubhist2-gotlandstidning-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-harnosandsposten-1840.yaml
+++ b/corpora/kubhist2-harnosandsposten-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-harnosandsposten-1850.yaml
+++ b/corpora/kubhist2-harnosandsposten-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-harnosandsposten-1860.yaml
+++ b/corpora/kubhist2-harnosandsposten-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-harnosandsposten-1870.yaml
+++ b/corpora/kubhist2-harnosandsposten-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-harnosandsposten-1880.yaml
+++ b/corpora/kubhist2-harnosandsposten-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-harnosandsposten-1890.yaml
+++ b/corpora/kubhist2-harnosandsposten-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-inrikestidningar-1760.yaml
+++ b/corpora/kubhist2-inrikestidningar-1760.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-inrikestidningar-1770.yaml
+++ b/corpora/kubhist2-inrikestidningar-1770.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-inrikestidningar-1780.yaml
+++ b/corpora/kubhist2-inrikestidningar-1780.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-inrikestidningar-1790.yaml
+++ b/corpora/kubhist2-inrikestidningar-1790.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-inrikestidningar-1800.yaml
+++ b/corpora/kubhist2-inrikestidningar-1800.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-inrikestidningar-1810.yaml
+++ b/corpora/kubhist2-inrikestidningar-1810.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-inrikestidningar-1820.yaml
+++ b/corpora/kubhist2-inrikestidningar-1820.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-jonkopingsbladet-1840.yaml
+++ b/corpora/kubhist2-jonkopingsbladet-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-jonkopingsbladet-1850.yaml
+++ b/corpora/kubhist2-jonkopingsbladet-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-jonkopingsbladet-1860.yaml
+++ b/corpora/kubhist2-jonkopingsbladet-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-jonkopingsbladet-1870.yaml
+++ b/corpora/kubhist2-jonkopingsbladet-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-jonkopingsposten-1860.yaml
+++ b/corpora/kubhist2-jonkopingsposten-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-jonkopingsposten-1870.yaml
+++ b/corpora/kubhist2-jonkopingsposten-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-jonkopingsposten-1880.yaml
+++ b/corpora/kubhist2-jonkopingsposten-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-jonkopingsposten-1890.yaml
+++ b/corpora/kubhist2-jonkopingsposten-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-kalmar-1860.yaml
+++ b/corpora/kubhist2-kalmar-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-kalmar-1870.yaml
+++ b/corpora/kubhist2-kalmar-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-kalmar-1880.yaml
+++ b/corpora/kubhist2-kalmar-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-kalmar-1890.yaml
+++ b/corpora/kubhist2-kalmar-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-kalmar-1900.yaml
+++ b/corpora/kubhist2-kalmar-1900.yaml
@@ -44,11 +44,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - text_title:
       label:
         eng: title

--- a/corpora/kubhist2-kalmar-1910.yaml
+++ b/corpora/kubhist2-kalmar-1910.yaml
@@ -69,11 +69,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - text_blingbring: text_blingbring
   - text_swefn: text_swefn
   - text_lix: text_lix

--- a/corpora/kubhist2-kalmar-kalmarlanstidning-1910.yaml
+++ b/corpora/kubhist2-kalmar-kalmarlanstidning-1910.yaml
@@ -69,11 +69,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - text_blingbring: text_blingbring
   - text_swefn: text_swefn
   - text_lix: text_lix

--- a/corpora/kubhist2-karlshamnsallehanda-1840.yaml
+++ b/corpora/kubhist2-karlshamnsallehanda-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-karlshamnsallehanda-1850.yaml
+++ b/corpora/kubhist2-karlshamnsallehanda-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-karlshamnsallehanda-1860.yaml
+++ b/corpora/kubhist2-karlshamnsallehanda-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-karlshamnsallehanda-1870.yaml
+++ b/corpora/kubhist2-karlshamnsallehanda-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-karlshamnsallehanda-1880.yaml
+++ b/corpora/kubhist2-karlshamnsallehanda-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-karlshamnsallehanda-1890.yaml
+++ b/corpora/kubhist2-karlshamnsallehanda-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-karlskronaweckoblad-1870.yaml
+++ b/corpora/kubhist2-karlskronaweckoblad-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-karlskronaweckoblad-1880.yaml
+++ b/corpora/kubhist2-karlskronaweckoblad-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-karlskronaweckoblad-1890.yaml
+++ b/corpora/kubhist2-karlskronaweckoblad-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-kristianstadsbladet-1850.yaml
+++ b/corpora/kubhist2-kristianstadsbladet-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-kristianstadsbladet-1860.yaml
+++ b/corpora/kubhist2-kristianstadsbladet-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-kristianstadsbladet-1870.yaml
+++ b/corpora/kubhist2-kristianstadsbladet-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-kristianstadsbladet-1880.yaml
+++ b/corpora/kubhist2-kristianstadsbladet-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-kristianstadsbladet-1890.yaml
+++ b/corpora/kubhist2-kristianstadsbladet-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-lindesbergsallehanda-1870.yaml
+++ b/corpora/kubhist2-lindesbergsallehanda-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-lindesbergsallehanda-1880.yaml
+++ b/corpora/kubhist2-lindesbergsallehanda-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-lundsweckoblad-1770.yaml
+++ b/corpora/kubhist2-lundsweckoblad-1770.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-lundsweckoblad-1780.yaml
+++ b/corpora/kubhist2-lundsweckoblad-1780.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-lundsweckoblad-1810.yaml
+++ b/corpora/kubhist2-lundsweckoblad-1810.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-lundsweckoblad-1820.yaml
+++ b/corpora/kubhist2-lundsweckoblad-1820.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-lundsweckoblad-1830.yaml
+++ b/corpora/kubhist2-lundsweckoblad-1830.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-lundsweckoblad-1840.yaml
+++ b/corpora/kubhist2-lundsweckoblad-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-lundsweckoblad-1850.yaml
+++ b/corpora/kubhist2-lundsweckoblad-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-lundsweckoblad-1860.yaml
+++ b/corpora/kubhist2-lundsweckoblad-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-lundsweckoblad-1870.yaml
+++ b/corpora/kubhist2-lundsweckoblad-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-lundsweckoblad-1880.yaml
+++ b/corpora/kubhist2-lundsweckoblad-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-lundsweckoblad-1890.yaml
+++ b/corpora/kubhist2-lundsweckoblad-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-malmoallehanda-1820.yaml
+++ b/corpora/kubhist2-malmoallehanda-1820.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-malmoallehanda-1830.yaml
+++ b/corpora/kubhist2-malmoallehanda-1830.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-malmoallehanda-1840.yaml
+++ b/corpora/kubhist2-malmoallehanda-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-malmoallehanda-1850.yaml
+++ b/corpora/kubhist2-malmoallehanda-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-malmoallehanda-1860.yaml
+++ b/corpora/kubhist2-malmoallehanda-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-malmoallehanda-1870.yaml
+++ b/corpora/kubhist2-malmoallehanda-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-malmoallehanda-1880.yaml
+++ b/corpora/kubhist2-malmoallehanda-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-malmoallehanda-1890.yaml
+++ b/corpora/kubhist2-malmoallehanda-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nerikesallehanda-1840.yaml
+++ b/corpora/kubhist2-nerikesallehanda-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nerikesallehanda-1850.yaml
+++ b/corpora/kubhist2-nerikesallehanda-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nerikesallehanda-1860.yaml
+++ b/corpora/kubhist2-nerikesallehanda-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nerikesallehanda-1870.yaml
+++ b/corpora/kubhist2-nerikesallehanda-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nerikesallehanda-1880.yaml
+++ b/corpora/kubhist2-nerikesallehanda-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nerikesallehanda-1890.yaml
+++ b/corpora/kubhist2-nerikesallehanda-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nlk-1850.yaml
+++ b/corpora/kubhist2-nlk-1850.yaml
@@ -39,11 +39,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nlk-1860.yaml
+++ b/corpora/kubhist2-nlk-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nlk-1870.yaml
+++ b/corpora/kubhist2-nlk-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norden-1850.yaml
+++ b/corpora/kubhist2-norden-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norden-1860.yaml
+++ b/corpora/kubhist2-norden-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norraskane-1880.yaml
+++ b/corpora/kubhist2-norraskane-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norraskane-1890.yaml
+++ b/corpora/kubhist2-norraskane-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrbottenskuriren-1860.yaml
+++ b/corpora/kubhist2-norrbottenskuriren-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrbottenskuriren-1870.yaml
+++ b/corpora/kubhist2-norrbottenskuriren-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrbottenskuriren-1880.yaml
+++ b/corpora/kubhist2-norrbottenskuriren-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrbottenskuriren-1890.yaml
+++ b/corpora/kubhist2-norrbottenskuriren-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrbottensposten-1840.yaml
+++ b/corpora/kubhist2-norrbottensposten-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrbottensposten-1850.yaml
+++ b/corpora/kubhist2-norrbottensposten-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrbottensposten-1860.yaml
+++ b/corpora/kubhist2-norrbottensposten-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrbottensposten-1870.yaml
+++ b/corpora/kubhist2-norrbottensposten-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrbottensposten-1880.yaml
+++ b/corpora/kubhist2-norrbottensposten-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrbottensposten-1890.yaml
+++ b/corpora/kubhist2-norrbottensposten-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingskuriren-1850.yaml
+++ b/corpora/kubhist2-norrkopingskuriren-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingskuriren-1860.yaml
+++ b/corpora/kubhist2-norrkopingskuriren-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingstidningar-1780.yaml
+++ b/corpora/kubhist2-norrkopingstidningar-1780.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingstidningar-1790.yaml
+++ b/corpora/kubhist2-norrkopingstidningar-1790.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingstidningar-1800.yaml
+++ b/corpora/kubhist2-norrkopingstidningar-1800.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingstidningar-1810.yaml
+++ b/corpora/kubhist2-norrkopingstidningar-1810.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingstidningar-1820.yaml
+++ b/corpora/kubhist2-norrkopingstidningar-1820.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingstidningar-1830.yaml
+++ b/corpora/kubhist2-norrkopingstidningar-1830.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingstidningar-1840.yaml
+++ b/corpora/kubhist2-norrkopingstidningar-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingstidningar-1850.yaml
+++ b/corpora/kubhist2-norrkopingstidningar-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingstidningar-1860.yaml
+++ b/corpora/kubhist2-norrkopingstidningar-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingstidningar-1870.yaml
+++ b/corpora/kubhist2-norrkopingstidningar-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingstidningar-1880.yaml
+++ b/corpora/kubhist2-norrkopingstidningar-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingstidningar-1890.yaml
+++ b/corpora/kubhist2-norrkopingstidningar-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingsweckotidningar-1750.yaml
+++ b/corpora/kubhist2-norrkopingsweckotidningar-1750.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingsweckotidningar-1760.yaml
+++ b/corpora/kubhist2-norrkopingsweckotidningar-1760.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingsweckotidningar-1770.yaml
+++ b/corpora/kubhist2-norrkopingsweckotidningar-1770.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrkopingsweckotidningar-1780.yaml
+++ b/corpora/kubhist2-norrkopingsweckotidningar-1780.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-norrlandsposten-1880.yaml
+++ b/corpora/kubhist2-norrlandsposten-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyadagligtallehanda-1850.yaml
+++ b/corpora/kubhist2-nyadagligtallehanda-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyadagligtallehanda-1860.yaml
+++ b/corpora/kubhist2-nyadagligtallehanda-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyadagligtallehanda-1870.yaml
+++ b/corpora/kubhist2-nyadagligtallehanda-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyadagligtallehanda-1880.yaml
+++ b/corpora/kubhist2-nyadagligtallehanda-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyadagligtallehanda-1890.yaml
+++ b/corpora/kubhist2-nyadagligtallehanda-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyakarlskronaweckoblad-1870.yaml
+++ b/corpora/kubhist2-nyakarlskronaweckoblad-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyawermlandstidningen-1850.yaml
+++ b/corpora/kubhist2-nyawermlandstidningen-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyawermlandstidningen-1860.yaml
+++ b/corpora/kubhist2-nyawermlandstidningen-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyawermlandstidningen-1870.yaml
+++ b/corpora/kubhist2-nyawermlandstidningen-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyawermlandstidningen-1880.yaml
+++ b/corpora/kubhist2-nyawermlandstidningen-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyawermlandstidningen-1890.yaml
+++ b/corpora/kubhist2-nyawermlandstidningen-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyawexjobladet-1840.yaml
+++ b/corpora/kubhist2-nyawexjobladet-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyawexjobladet-1850.yaml
+++ b/corpora/kubhist2-nyawexjobladet-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyawexjobladet-1860.yaml
+++ b/corpora/kubhist2-nyawexjobladet-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyawexjobladet-1870.yaml
+++ b/corpora/kubhist2-nyawexjobladet-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyawexjobladet-1880.yaml
+++ b/corpora/kubhist2-nyawexjobladet-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyawexjobladet-1890.yaml
+++ b/corpora/kubhist2-nyawexjobladet-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyttallvarochskamt-1840.yaml
+++ b/corpora/kubhist2-nyttallvarochskamt-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyttallvarochskamt-1850.yaml
+++ b/corpora/kubhist2-nyttallvarochskamt-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyttochgammalt-1780.yaml
+++ b/corpora/kubhist2-nyttochgammalt-1780.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyttochgammalt-1790.yaml
+++ b/corpora/kubhist2-nyttochgammalt-1790.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyttochgammalt-1800.yaml
+++ b/corpora/kubhist2-nyttochgammalt-1800.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-nyttochgammalt-1810.yaml
+++ b/corpora/kubhist2-nyttochgammalt-1810.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ostergotlandsveckoblad-1880.yaml
+++ b/corpora/kubhist2-ostergotlandsveckoblad-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ostergotlandsveckoblad-1890.yaml
+++ b/corpora/kubhist2-ostergotlandsveckoblad-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ostgotacorrespondenten-1830.yaml
+++ b/corpora/kubhist2-ostgotacorrespondenten-1830.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ostgotacorrespondenten-1840.yaml
+++ b/corpora/kubhist2-ostgotacorrespondenten-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ostgotacorrespondenten-1850.yaml
+++ b/corpora/kubhist2-ostgotacorrespondenten-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ostgotacorrespondenten-1860.yaml
+++ b/corpora/kubhist2-ostgotacorrespondenten-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ostgotacorrespondenten-1870.yaml
+++ b/corpora/kubhist2-ostgotacorrespondenten-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ostgotacorrespondenten-1880.yaml
+++ b/corpora/kubhist2-ostgotacorrespondenten-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ostgotacorrespondenten-1890.yaml
+++ b/corpora/kubhist2-ostgotacorrespondenten-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ostgotaposten-1890.yaml
+++ b/corpora/kubhist2-ostgotaposten-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-ostgotaposten-1900.yaml
+++ b/corpora/kubhist2-ostgotaposten-1900.yaml
@@ -59,11 +59,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
 pos_attributes:
   - ne_ex: ne_ex
   - ne_name: ne_name

--- a/corpora/kubhist2-ostgotaposten-1910.yaml
+++ b/corpora/kubhist2-ostgotaposten-1910.yaml
@@ -69,11 +69,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - text_blingbring: text_blingbring
   - text_swefn: text_swefn
   - text_lix: text_lix

--- a/corpora/kubhist2-post-ochinrikestidningar-1820.yaml
+++ b/corpora/kubhist2-post-ochinrikestidningar-1820.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-post-ochinrikestidningar-1830.yaml
+++ b/corpora/kubhist2-post-ochinrikestidningar-1830.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-post-ochinrikestidningar-1840.yaml
+++ b/corpora/kubhist2-post-ochinrikestidningar-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-post-ochinrikestidningar-1850.yaml
+++ b/corpora/kubhist2-post-ochinrikestidningar-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-post-ochinrikestidningar-1860.yaml
+++ b/corpora/kubhist2-post-ochinrikestidningar-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-post-ochinrikestidningar-1870.yaml
+++ b/corpora/kubhist2-post-ochinrikestidningar-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-post-ochinrikestidningar-1880.yaml
+++ b/corpora/kubhist2-post-ochinrikestidningar-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-post-ochinrikestidningar-1890.yaml
+++ b/corpora/kubhist2-post-ochinrikestidningar-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1640.yaml
+++ b/corpora/kubhist2-posttidningar-1640.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1650.yaml
+++ b/corpora/kubhist2-posttidningar-1650.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1660.yaml
+++ b/corpora/kubhist2-posttidningar-1660.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1670.yaml
+++ b/corpora/kubhist2-posttidningar-1670.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1680.yaml
+++ b/corpora/kubhist2-posttidningar-1680.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1690.yaml
+++ b/corpora/kubhist2-posttidningar-1690.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1700.yaml
+++ b/corpora/kubhist2-posttidningar-1700.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1710.yaml
+++ b/corpora/kubhist2-posttidningar-1710.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1720.yaml
+++ b/corpora/kubhist2-posttidningar-1720.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1730.yaml
+++ b/corpora/kubhist2-posttidningar-1730.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1740.yaml
+++ b/corpora/kubhist2-posttidningar-1740.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1750.yaml
+++ b/corpora/kubhist2-posttidningar-1750.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1760.yaml
+++ b/corpora/kubhist2-posttidningar-1760.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1770.yaml
+++ b/corpora/kubhist2-posttidningar-1770.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1780.yaml
+++ b/corpora/kubhist2-posttidningar-1780.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1790.yaml
+++ b/corpora/kubhist2-posttidningar-1790.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1800.yaml
+++ b/corpora/kubhist2-posttidningar-1800.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1810.yaml
+++ b/corpora/kubhist2-posttidningar-1810.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-posttidningar-1820.yaml
+++ b/corpora/kubhist2-posttidningar-1820.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-stnlk-1870.yaml
+++ b/corpora/kubhist2-stnlk-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-stockholmsdagblad-1820.yaml
+++ b/corpora/kubhist2-stockholmsdagblad-1820.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-stockholmsdagblad-1830.yaml
+++ b/corpora/kubhist2-stockholmsdagblad-1830.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-stockholmsdagblad-1840.yaml
+++ b/corpora/kubhist2-stockholmsdagblad-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-stockholmsdagblad-1850.yaml
+++ b/corpora/kubhist2-stockholmsdagblad-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-stockholmsdagblad-1860.yaml
+++ b/corpora/kubhist2-stockholmsdagblad-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-stockholmsdagblad-1870.yaml
+++ b/corpora/kubhist2-stockholmsdagblad-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-stockholmsdagblad-1880.yaml
+++ b/corpora/kubhist2-stockholmsdagblad-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-stockholmsdagblad-1890.yaml
+++ b/corpora/kubhist2-stockholmsdagblad-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-stockholmsposten-1770.yaml
+++ b/corpora/kubhist2-stockholmsposten-1770.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-stockholmsposten-1780.yaml
+++ b/corpora/kubhist2-stockholmsposten-1780.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-stockholmsposten-1790.yaml
+++ b/corpora/kubhist2-stockholmsposten-1790.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-stockholmsposten-1800.yaml
+++ b/corpora/kubhist2-stockholmsposten-1800.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-stockholmsposten-1810.yaml
+++ b/corpora/kubhist2-stockholmsposten-1810.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-stockholmsposten-1820.yaml
+++ b/corpora/kubhist2-stockholmsposten-1820.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-stockholmsposten-1830.yaml
+++ b/corpora/kubhist2-stockholmsposten-1830.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-sundsvallstidning-1880.yaml
+++ b/corpora/kubhist2-sundsvallstidning-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-sundsvallstidning-1890.yaml
+++ b/corpora/kubhist2-sundsvallstidning-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-tfwbsol-1840.yaml
+++ b/corpora/kubhist2-tfwbsol-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-tfwbsol-1850.yaml
+++ b/corpora/kubhist2-tfwbsol-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-tfwbsol-1860.yaml
+++ b/corpora/kubhist2-tfwbsol-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-tfwbsol-1870.yaml
+++ b/corpora/kubhist2-tfwbsol-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-tfwbsol-1880.yaml
+++ b/corpora/kubhist2-tfwbsol-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-tfwbsol-1890.yaml
+++ b/corpora/kubhist2-tfwbsol-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-umebladet-1840.yaml
+++ b/corpora/kubhist2-umebladet-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-umebladet-1850.yaml
+++ b/corpora/kubhist2-umebladet-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-umebladet-1860.yaml
+++ b/corpora/kubhist2-umebladet-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-umebladet-1870.yaml
+++ b/corpora/kubhist2-umebladet-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-umebladet-1880.yaml
+++ b/corpora/kubhist2-umebladet-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-umebladet-1890.yaml
+++ b/corpora/kubhist2-umebladet-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-upsala-1840.yaml
+++ b/corpora/kubhist2-upsala-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-upsala-1850.yaml
+++ b/corpora/kubhist2-upsala-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-upsala-1860.yaml
+++ b/corpora/kubhist2-upsala-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-upsala-1870.yaml
+++ b/corpora/kubhist2-upsala-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-upsala-1880.yaml
+++ b/corpora/kubhist2-upsala-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-upsala-1890.yaml
+++ b/corpora/kubhist2-upsala-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-vestmanlandslanstidning-1830.yaml
+++ b/corpora/kubhist2-vestmanlandslanstidning-1830.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-vestmanlandslanstidning-1840.yaml
+++ b/corpora/kubhist2-vestmanlandslanstidning-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-vestmanlandslanstidning-1850.yaml
+++ b/corpora/kubhist2-vestmanlandslanstidning-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-vestmanlandslanstidning-1860.yaml
+++ b/corpora/kubhist2-vestmanlandslanstidning-1860.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-vestmanlandslanstidning-1870.yaml
+++ b/corpora/kubhist2-vestmanlandslanstidning-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-vestmanlandslanstidning-1880.yaml
+++ b/corpora/kubhist2-vestmanlandslanstidning-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-vestmanlandslanstidning-1890.yaml
+++ b/corpora/kubhist2-vestmanlandslanstidning-1890.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-wermlandslanstidning-1870.yaml
+++ b/corpora/kubhist2-wermlandslanstidning-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-wermlandstidningen-1840.yaml
+++ b/corpora/kubhist2-wermlandstidningen-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-wermlandstidningen-1850.yaml
+++ b/corpora/kubhist2-wermlandstidningen-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-wernamotidning-1870.yaml
+++ b/corpora/kubhist2-wernamotidning-1870.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-wernamotidning-1880.yaml
+++ b/corpora/kubhist2-wernamotidning-1880.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-wexjobladet-1810.yaml
+++ b/corpora/kubhist2-wexjobladet-1810.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-wexjobladet-1820.yaml
+++ b/corpora/kubhist2-wexjobladet-1820.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-wexjobladet-1830.yaml
+++ b/corpora/kubhist2-wexjobladet-1830.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-wexjobladet-1840.yaml
+++ b/corpora/kubhist2-wexjobladet-1840.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:

--- a/corpora/kubhist2-wexjobladet-1850.yaml
+++ b/corpora/kubhist2-wexjobladet-1850.yaml
@@ -40,11 +40,7 @@ struct_attributes:
       label:
         eng: source
         swe: källa
-      pattern: <div><div>Kungliga Biblioteket</div><div><a href='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>/' target='_blank'><img src='https://tidningar.kb.se/<%=
-        struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition
-        %>/part/1/page/<%= struct_attrs.Page_n %>_thumb.jpg' width='100%'></img></a></div></div>
+      pattern: <a href="https://tidningar.kb.se/<%=struct_attrs.text_libris %>/<%= struct_attrs.text_date %>/edition/<%= struct_attrs.text_edition" target="_blank">Kungliga biblioteket</a>
   - Page_n: page
   - String_wordbreak:
       label:


### PR DESCRIPTION
The thumbnails are no longer at the old location. Not clear how to replace them, so removing them for now.